### PR TITLE
Add BAM input, skip-annotation mode, and fix EarlGrey/BUSCO bugs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -45,25 +45,28 @@ workflow {
         error "ERROR: 'genome_assembly' is required in your config."
     }
 
-    // 1. TE Masking
-    def masked_asm_ch
-    if (params.masked_genome) {
-        log.info "Mode: Skipping TE annotation. Using provided masked genome."
-        masked_asm_ch = Channel.fromPath(params.masked_genome)
-    } else {
-        log.info "Mode: Full pipeline. Masking genome with Earlgrey."
-        annotate_TEs(Channel.fromPath(params.genome_assembly))
-        masked_asm_ch = annotate_TEs.out.masked_asm
-    }
-
-    // 2. Structural Annotation
     def braker_annots_ch
     def braker_aa_ch
+
     if (params.gene_annotation_gff && params.transcript_aa_fasta) {
-        log.info "Mode: Skipping BRAKER4. Using provided GFF and AA FASTA."
+        // Skip EarlGrey and BRAKER4 entirely — use provided annotations
+        log.info "Mode: Skipping EarlGrey and BRAKER4. Using provided GFF and AA FASTA."
         braker_annots_ch = Channel.fromPath(params.gene_annotation_gff)
         braker_aa_ch     = Channel.fromPath(params.transcript_aa_fasta)
+
     } else {
+        // 1. TE Masking
+        def masked_asm_ch
+        if (params.masked_genome) {
+            log.info "Mode: Skipping TE annotation. Using provided masked genome."
+            masked_asm_ch = Channel.fromPath(params.masked_genome)
+        } else {
+            log.info "Mode: Full pipeline. Masking genome with Earlgrey."
+            annotate_TEs(Channel.fromPath(params.genome_assembly))
+            masked_asm_ch = annotate_TEs.out.masked_asm
+        }
+
+        // 2. Structural Annotation
         def rna_ch
         if (params.bam) {
             log.info "Mode: Braker4 with BAM and Protein evidence."

--- a/modules/Busco.nf
+++ b/modules/Busco.nf
@@ -13,7 +13,7 @@ process runBrakerBusco {
     """
     busco -i ${braker_aa} -o busco_output \
     -m prot \
-    -l actinopterygii_odb12 \
+    -l ${params.busco_lineage} \
     --download_path ${params.busco_download_path} \
     -c ${params.nthreads} --offline
     """


### PR DESCRIPTION
## Summary

- **Skip-annotation mode**: if `gene_annotation_gff` and `transcript_aa_fasta` are both provided in the params YAML, the pipeline skips EarlGrey and BRAKER4 entirely and runs only functional annotation
- **BAM input for BRAKER4**: if `bam` is set in the params YAML, BRAKER4 uses pre-aligned BAM(s) instead of FASTQ reads (accepts a glob for multiple files); `bam` takes priority over `rna_reads`
- **README rewrite**: quick start on top, run modes as a plain table, written for biologists
- **params_template.yaml updated**: all current params documented with plain-English comments
- **Bug fix**: EarlGrey was being submitted even in skip-annotation mode — restructured `main.nf` so masking and structural annotation are nested inside the same else branch
- **Bug fix**: `Busco.nf` was hardcoding `actinopterygii_odb12` instead of using `params.busco_lineage`

## New params

```yaml
bam: null                  # pre-aligned RNA-seq BAM; accepts a glob e.g. "/path/*.bam"
gene_annotation_gff: null  # skip to functional annotation if you already have a GFF
transcript_aa_fasta: null  # required alongside gene_annotation_gff
```

## Test plan

- [ ] Full pipeline: `genome_assembly` only — EarlGrey → BRAKER4 protein-only → functional annotation
- [ ] Skip masking: `masked_genome` provided — skips EarlGrey, rest runs normally
- [ ] RNA reads: `rna_reads` provided — BRAKER4 uses FASTQ R1/R2
- [ ] BAM mode: `bam` provided — BRAKER4 uses BAM, fastq_r1/r2 columns empty in samples.csv
- [ ] Skip-annotation mode: `gene_annotation_gff` + `transcript_aa_fasta` — only functional annotation runs, EarlGrey does NOT run

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxY4VZGVKEP3pkKqbynM4B)_