### PR TITLE
Add BAM input, skip-annotation mode, and various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cp params_template.yaml params.yaml
 **2. Fill in your params.yaml**
 ```yaml
 species_id: "MySpecies1"              # a short label for your species
-genome_assembly: "/path/to/genome.fasta"
+genome_assembly: "/path/to/genome.fasta"  # not needed if using gene_annotation_gff + transcript_aa_fasta
 
 # Optional — leave as null if you don't have these
 masked_genome: null        # skip repeat masking if you already have a masked genome
@@ -45,7 +45,7 @@ The pipeline figures out what to run based on what you provide. You don't need t
 | `genome_assembly` | Full pipeline: mask genome → structural annotation (protein-only) → functional annotation |
 | + `rna_reads` or `bam` | Same as above but uses RNA evidence in structural annotation |
 | + `masked_genome` | Skips repeat masking, uses your masked genome directly |
-| + `gene_annotation_gff` and `transcript_aa_fasta` | Skips masking and structural annotation entirely, runs functional annotation only |
+| `gene_annotation_gff` + `transcript_aa_fasta` (no genome needed) | Skips everything, runs functional annotation only |
 
 ---
 

--- a/main.nf
+++ b/main.nf
@@ -41,10 +41,6 @@ workflow {
     log.info "FeatureFlow Initializing..."
     log.info "========================================================"
 
-    if (!params.genome_assembly) {
-        error "ERROR: 'genome_assembly' is required in your config."
-    }
-
     def braker_annots_ch
     def braker_aa_ch
 
@@ -55,6 +51,10 @@ workflow {
         braker_aa_ch     = Channel.fromPath(params.transcript_aa_fasta)
 
     } else {
+        if (!params.genome_assembly) {
+            error "ERROR: 'genome_assembly' is required in your config."
+        }
+
         // 1. TE Masking
         def masked_asm_ch
         if (params.masked_genome) {
@@ -76,7 +76,7 @@ workflow {
             rna_ch = Channel.fromPath("${params.rna_reads}/*{_R1,_R2,_1,_2}*.fastq*").collect()
         } else {
             log.info "Mode: Braker4 Protein-only evidence."
-            rna_ch = Channel.of( [file("/dev/null")] )
+            rna_ch = Channel.of([])
         }
         runBraker4(Channel.fromPath(params.genome_assembly), masked_asm_ch, rna_ch, params.protein_ref)
         braker_annots_ch = runBraker4.out.braker_annots

--- a/params_template.yaml
+++ b/params_template.yaml
@@ -1,6 +1,9 @@
 # ---- Required ---------------------------------------------------------------
 species_id: null                        # Short label for your species, e.g. "MySpecies1"
+
+# ---- Required (unless using gene_annotation_gff + transcript_aa_fasta) ------
 genome_assembly: null                   # Path to unmasked genome FASTA
+
 # ---- Optional: skip repeat masking ------------------------------------------
 masked_genome: null                     # Provide to skip EarlGrey
 


### PR DESCRIPTION
## Summary

- **Skip-annotation mode**: if `gene_annotation_gff` and `transcript_aa_fasta` are both provided, the pipeline skips EarlGrey and BRAKER4 entirely and runs only functional annotation. `genome_assembly` is not required in this mode.
- **BAM input for BRAKER4**: if `bam` is set, BRAKER4 uses pre-aligned BAM(s) instead of FASTQ reads (accepts a glob for multiple files); `bam` takes priority over `rna_reads`
- **Protein-only mode**: replaced `/dev/null` hack with `Channel.of([])` — an empty list that stages no files and lets the findAll/collect calls return empty strings naturally
- **Bug fix**: EarlGrey was being submitted even in skip-annotation mode — masking and structural annotation are now nested inside the same else branch
- **Bug fix**: `Busco.nf` was hardcoding `actinopterygii_odb12` instead of using `params.busco_lineage`
- **README rewrite**: quick start on top, run modes as a plain table, written for biologists
- **params_template.yaml updated**: all current params documented with plain-English comments

## New params

```yaml
bam: null                  # pre-aligned RNA-seq BAM; accepts a glob e.g. "/path/*.bam"
gene_annotation_gff: null  # skip to functional annotation if you already have a GFF
transcript_aa_fasta: null  # required alongside gene_annotation_gff
```

## Test plan

- [ ] Full pipeline: `genome_assembly` only — EarlGrey → BRAKER4 protein-only → functional annotation
- [ ] Skip masking: `masked_genome` provided — skips EarlGrey, rest runs normally
- [ ] RNA reads: `rna_reads` provided — BRAKER4 uses FASTQ R1/R2
- [ ] BAM mode: `bam` provided — BRAKER4 uses BAM, fastq_r1/r2 columns empty in samples.csv
- [ ] Skip-annotation mode: `gene_annotation_gff` + `transcript_aa_fasta` only (no genome) — only functional annotation runs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxY4VZGVKEP3pkKqbynM4B)_